### PR TITLE
Symm univ setbundle circle

### DIFF
--- a/circle.tex
+++ b/circle.tex
@@ -1243,7 +1243,7 @@ function $\bn 1\to X$ defined by $\cst x (\ast) \defequi x$ on the
 unique element $\ast: \bn 1$. In particular,
 $\cst \base : \bn 1 \to \Sc$ denotes the universal \covering of $\Sc$.
 
-\begin{theorem}
+\begin{theorem}~%
   \label{thm:coveringsofS1}
   \begin{enumerate}
   \item \label{item:univ-cover-Sc-Z}%
@@ -1251,17 +1251,33 @@ $\cst \base : \bn 1 \to \Sc$ denotes the universal \covering of $\Sc$.
     $\Sc \weq \conncomp {\SetBundle(\Sc)} {\cst \base}$ mapping
     $\base$ to $(\cst \base, \trunc{\refl {\cst \base}})$.
     
-%   The set $c_\base=c_\base$ of symmetries of the universal \covering of the circle is equivalent to $\zet$.  
-% Furthermore, there is a symmetry $$Q^1:c_\base=c_\base$$ so that, considered as an element in $\sum_{X:\Set}X=X$ the pair $(c_\base=c_\base,Q^1)$ is equal to $(\zet,s)$.  
+    % The set $c_\base=c_\base$ of symmetries of the universal
+    % \covering of the circle is equivalent to $\zet$.  Furthermore,
+    % there is a symmetry $$Q^1:c_\base=c_\base$$ so that, considered
+    % as an element in $\sum_{X:\Set}X=X$ the pair
+    % $(c_\base=c_\base,Q^1)$ is equal to $(\zet,s)$.
 
-% The component of the type of \coverings over the circle containing the universal \covering is equivalent to the circle via the map from $S^1$ sending $\base$ to $c_\base$ and $\Sloop$ to $Q^1$.
-%
-  \item For a positive integer $m$, the set $-^m=-^m$ of symmetries of
-    the $m$-fold \covering of the circle is equivalent to $\bn m$.
+    % The component of the type of \coverings over the circle
+    % containing the universal \covering is equivalent to the circle
+    % via the map from S^1$ sending $\base$ to $c_\base$ and
+    % $\Sloop$ to $Q^1$.%
+  \item \label{item:setbundle-mcover}%
+    For a positive integer $m$, the set
+    $\blank^m=\blank^m$ of symmetries of the
+    $m$-fold \covering of the circle is equivalent to the finite type
+    $\bn m$.
 
-Furthermore, there is a symmetry $$Q^1:-^m=-^m$$ so that considered as an element in $\sum_{X:\Set}X=X$ the pair $(-^m=-^m,Q^1)$ is equal to $\zet/m$ of \cref{def:Zetmodm}.
+    Furthermore, there is a symmetry
+    \begin{displaymath}
+      Q^1:\blank^m=_{\SetBundle(\Sc)}\blank^m
+    \end{displaymath}
+    so that every symmetry of $\blank^m$ (as set bundle over
+    $\Sc$) writes as $(Q^1)^i$ for a uniquely determined $i$ between
+    $0$ and $m-1$. In other words, following \cref{def:Zetmodm},
+    \begin{displaymath}
+      \conncomp{\SetBundle(\Sc)}{\blank^m} \weq \conncomp{\left(\sum_{X:\Set}X=X\right)}{\zet/m}.
+    \end{displaymath}
 
-The component of the type of \coverings over the circle containing the $m$-fold covering is equivalent to $$\sum_{X:\Set}\sum_{p:X=X}\Trunc{(X,p)=\zet/m}.$$
   \end{enumerate}
  \end{theorem}
 \begin{remark}\label{rem:thenonuniquenessofgeneratorsofmodulararithmetic1}
@@ -1311,45 +1327,262 @@ The component of the type of \coverings over the circle containing the $m$-fold 
 % Using the equivalence $\ev_0:((\zet,s)=_C(\zet,s))\equiv\zet$ of \cref{lem:IdCisZet}, this
 %  reduces to 
 % $$D_0\simeq P\times\zet\simeq\zet.$$
-    
-((this does most of what is needed for the $m$-fold \covering.  Needs to be proofread))
-    Let $m$ be a positive integer.  
-Recall the $m$-fold \covering, either in the guise $-^m:\Sc\to \Sc$ of \cref{exa:mfoldS1cover} or $-^m:C\to C$ of \cref{exa:mfoldCcover}.
-We are going to investigate the set
-$$D_m\defequi\sum_{g:\Sc=\Sc}-^mg=_{\Sc\to \Sc}-^m$$  
-of symmetries of the $m$-fold \covering of the circle.  
-By univalence and thanks to the equivalence $c:\Sc\to C$ of \cref{thm:S1bysymmetries} $(\Sc= \Sc)$ is equivalent to $(\Sc\simeq C)$.
-Since being contractible is a proposition, $\Sc\simeq C$ is a subtype of $\Sc\to C$,
-which by \cref{lem:freeloopspace} is ultimately equivalent to $\sum_{(Y,g,!):C}(Y,g,!)=(Y,g,!)$. 
-For the moment we'll investigate the simpler type 
-$$F_m\defequi\sum_{t:\Sc\to C}-^mt=_{\Sc\to C}-^mc$$
-and on the way discover that if $(t,Q):F_m$, then $t$ is an equivalence, so that $F_m$ actually {\bf is} equivalent to the type $D_m$ we are interested in.
 
-Given If $t:\Sc\to C$ is given by $t(\base)\defequi (Y,g,!)$ (where $!$ asserts that $(Y,g)$ lies in the component of $(\zet,s)$)  and $t(\Sloop)=(p,!,!):(Y,g,!)=_C(Y,g,!)$, (where $p:Y=Y$ and $pg=gp$ (an identity in the set $Y=Y$)), we study the type $-^mt=_{\Sc\to C}-^mc$.
-Spelling out the details we see that $-^mc$ is defined by 
-$$-^mc(\base)=(\bn m\times\zet,\sqrt[m]s,!)$$ and 
-$$-^mc(\Sloop)\defequi(\id\times s,!,!):(\bn m\times\zet,\sqrt[m]s,!)=_C(\bn m\times\zet,\sqrt[m]s,!)$$   and $-^mt$ is given by $$-^mt(\base)\oldequiv(\bn m\times Y,\sqrt[m]g,!)$$ and 
-$$-^mt(\Sloop)\oldequiv(\id\times p,!,!):(\bn m\times Y,\sqrt[m]g,!)=_C(\bn m\times Y,\sqrt[m]g,!).$$
+%% temporary definition
+  \def\blank{{-}}%
+  \def\mono{\hookrightarrow}%
+  \def\bigetop#1{\overline{#1}}%
+  \def\bigptoe#1{\widetilde{#1}}%
+  \def\inv#1{#1^{-1}}%
+  \def\myq{\mathfrak m}%
+  \renewcommand{\trp}[2][\null]{%
+    \ifx#1\null\mathop{\mathit{trp}_{#2}}%
+    \else\mathop{\mathit{trp}_{#1,#2}}%
+    \fi%
+  }%
+  \def\bigetop#1{{#1}}%
+  \def\bigptoe#1{{#1}}%
+  \def\etop#1{{#1}}%
+  \def\ptoe#1{{#1}}%
+  %%
+  Let us move on to (\ref{item:setbundle-mcover}). %
+  First, let us emphasize that we are interested in the symmetries of
+  $\blank^m$ {\em as a set bundle}, meaning we shall explore
+  $(\Sc,\blank^m) =_X (\Sc,\blank^m)$ where $X$ is the type
+  $\SetBundle(\Sc)$.
+  % (and not $\Sc\to \Sc$)
+  Because $\SetBundle(\Sc)$ is a subtype of $\sum_{A:\UU}A\to \Sc$, it
+  is enough to determine the symmetries of $(\Sc,\blank^m)$ in this later
+  type (cf.\ \cref{lem:subtype-eq-=}). This is unfolded as:
+  \begin{displaymath}
+    D_m \defequi \sum_{g:\Sc = \Sc}\blank^m =_{\Sc \to \Sc} \blank^m\ptoe g 
+  \end{displaymath}
+  Recall the equivalence $c: \Sc \to C$ of
+  \cref{thm:S1bysymmetries}. Then the transport along $\etop c$ in the
+  type family $X\mapsto (\Sc=X)$ is an equivalence from $(\Sc = \Sc)$
+  to $(\Sc = C)$. Composing with univalence, we get that an
+  equivalence $(\Sc=\Sc) \to (\Sc \weq C)$ mapping
+  $g\mapsto c\circ \ptoe g$, with pseudo inverse
+  $t \mapsto \bigetop{\inv c \circ f}$. Hence, by following ((need a
+  ref to exercise there)),
+  \begin{displaymath}
+    D_m \weq  \sum_{t:\Sc \weq C} \blank^m =_{\Sc\to \Sc} \blank^m\inv c t
+  \end{displaymath}
+  Then, denoting $\blank^m_C: C \to C$ for the $m$-fold cover of $C$,
+  \begin{displaymath}
+    \begin{split}
+      (\blank^m =_{\Sc\to \Sc} \blank^m\inv c t) %
+      &\weq (c (\blank^m) =_{\Sc\to C} c (\blank^m) \inv c t)
+      \\
+      &\weq (\blank^m_Cc =_{\Sc\to C} \blank^m_C t)
+    \end{split}
+  \end{displaymath}
+  where the first equivalence holds because $c$ is an equivalence, and
+  the second because $\blank^m_Cc =_{\Sc\to C} c (\blank^m)$ has been
+  proved in \cref{exa:mfoldCcover}. As in \cref{exa:mfoldCcover}, we
+  shall drop the $C$ in index and just write $\blank^m$ for the
+  $m$-fold cover of $C$. Then if we write
+  \begin{displaymath}
+    F_m \defequi \sum_{t:\Sc \weq C}(\blank^mc =_{\Sc\to C} \blank^m t),
+  \end{displaymath}
+  one gets that $D_m \weq F_m$ and we can now concentrate on proving that
+  $F_m \weq \bn m$.
 
-An element in $Q:-^mc=-^mt$ is then given by a 
-$$q:\bn m\times\zet=\bn m\times Y$$ so that $\sqrt[m]g\ q=q\sqrt[m]s$ and $q(\id\times s)=(\id\times p)q$ (both in $\bn m\times\zet=\bn m\times Y$). 
-Now, the element $$q^{-1}(\id\times s)q=q^{-1}(\sqrt[m]s)^mq=(q^{-1}\sqrt[m]sq)^m$$ in $\bn m\times Y=\bn m\times Y$ is both equal to $\id\times p$ and equal to $(\sqrt[m]g)^m=\id\times g$, proving that $p=g$. 
+  Let us first sketch the proof in three steps:
+  \begin{enumerate}[label={\sc Step \arabic*}.]
+  \item We shall describe the elements of $F_m$ as basically tuples
+    $(Y,g,q)$ with $(Y,g)$ in the subtype $C$ of $\sum_{X:\UU}(X=X)$
+    and $q:\bn m\times \zet = \bn m\times Y$ such that $q$ satisfies
+    certain propositional equations, denoted $E(q)$ here.
+  \item We shall then give a characterization of these elements
+    $(Y,g,q)$ in the case where $Y$ is $\zet$ and $g$ is $\etop
+    s$. This characterization will give $q$ (viewed as an equivalence)
+    the following form:
+    \begin{displaymath}
+      q_{i,n}: (j,z) \mapsto {\sqrt[m]s}^j(i,n+z)
+    \end{displaymath}
+    In particular, it can be seen that
+    $(\zet,\etop s,q_{i,n}) = (\zet,\etop s,q_{i,0})$ in $F_m$.
+  \item Finally we shall define a map $\myq: \bn m \to F_m$ properly
+    as $i\mapsto (\zet,\etop s,q_{i,0})$ and prove that it is an
+    equivalence. It means that given $(Y,g,!):C$, one has to show
+    \begin{displaymath}
+      P(Y,g) \defequi \prod_{q:\bn m \times \zet = \bn m \times Y}E(q)\to\iscontr(\inv{\myq}(Y,g,q))
+    \end{displaymath}
+    where $E(q)$ is as in step 1. The dependent product is valued in
+    propositions so $P(Y,g)$ itself is a proposition. By definition of
+    $C$, $(Y,g)$ lies in the same connected component as $(Z,\etop s)$
+    in $\sum_{X:\UU}X=X$, so using \cref{xca:component-connected},
+    $P(Y,g)$ holds as soon as $P(Z,\etop s)$ holds. Otherwise put, it
+    is enough to prove the contractibility of the fiber of $\myq$ at
+    elements of $F_m$ of the form $(Z,\etop s,q)$ for which step 2
+    shows that $q$ must be one of the $q_{i,n}$ for some $(i,n)$. This
+    $i$, together with the essentially unique proof that
+    $(\zet,\etop s, q_{i,n}) = (\zet,\etop s, q_{i,0})$, is then
+    easily seen to be a center of contraction for the fiber
+    $\inv\myq(Z,\etop s, q)$.
+  \end{enumerate}
+
+  {\sc Step 1.} An element of $F_m$ is given by a map $t:\Sc \to C$
+  together with a term $!:\isEq(t)$ and a proof
+  $Q: \blank^mc = \blank^mt$. Now such a $t$ can be reduced through
+  the universal property of $\Sc$ to the data of
+  $t(\base)\defequi (Y,g,!)$ and
+  $t(\Sloop)\defis (p,!,!): (Y,g,!) =_C (Y,g,!)$. Under identification
+  through the universal property of $\Sc$, $\blank^mc$ is given by
+  \begin{displaymath}
+    \begin{split}
+      &\blank^mc(\base) \defequi (\bn m\times \zet,\sqrt[m] {\etop s},!)\\
+      &\blank^mc(\Sloop) \defis (\id \times {\etop s},!,!): (\bn
+      m\times \zet,\sqrt[m] {\etop s},!) =_C (\bn m\times
+      \zet,\sqrt[m] {\etop s},!)
+    \end{split}
+  \end{displaymath}
+  and similarly $\blank^mt$ is given by
+  \begin{displaymath}
+    \begin{split}
+      &\blank^mt(\base) \defequi (\bn m\times Y,\sqrt[m] g,!)\\
+      &\blank^mt(\Sloop) \defis (\id \times p,!,!): (\bn m\times
+      Y,\sqrt[m] g,!) =_C (\bn m\times Y,\sqrt[m] g,!)
+    \end{split}
+  \end{displaymath}
+  By function extensionality and $\Sc$-induction, $Q$ becomes then a
+  term $q:\bn m\times \zet = \bn m\times Y$ such that the two
+  following propositions hold, whose product is denoted $E(q)$:
+  \begin{displaymath}
+    {\sqrt[m]g} \circ q = q \circ \sqrt[m]{\etop s}%
+    \quad\text{and}\quad%
+    q \circ (\id \times {\etop s}) = (\id \times p) \circ q.%
+  \end{displaymath}
+  Remark that repeated applications of the first equation imply that
+  such a $q$ is completely determined by
+  $\ptoe q (0,0): \bn m\times Y$: indeed for all $j\in\bn m$ and
+  $z\in\zet$
+  \begin{displaymath}
+    \ptoe q (j,z) = \ptoe q ( \sqrt[m]s^{j+zm} (0,0))%
+    = \sqrt[m]g^{j+zm} \ptoe q(0,0)%
+  \end{displaymath}
+  Remark also for future references that the proposition $p=g$ holds:
+  indeed,
+  \begin{displaymath}
+    \id \times p = q \circ (\id \times {\etop s}) \circ q^{-1}
+    = (q\sqrt[m]{\etop s}q^{-1})^m = (\sqrt[m]g)^m = \id \times g.
+  \end{displaymath}
+  
+  {\sc Step 2.} In particular, when $t$ is actually $c$, then $Y$ is $\zet$, and $g$
+  and $p$ are both $\etop s$. Define then for each pair
+  $(i,n)\in\bn m \times \zet$ a function
+  $q_{i,n}:\bn m\times\zet \to \bn m\times\zet$ as follows:
+  \begin{displaymath}
+    (j,z) \mapsto \sqrt[m]s^{j+zm}(i,n)%
+  \end{displaymath}
+  Such a $q_{i,n}$ is an equivalence as it admits $q_{m-i,-n-1}$ as
+  pseudo inverse. Moreover direct computations show easily that the
+  propositions $\sqrt[m] s q_{i,n} = q_{i,n}\sqrt[m] s$ and
+  $q_{i,n} \circ (\id \times s) = (\id \times s) \circ q_{i,n}$ are
+  satisfied. In other words, for each $(i,n):\bn m \times \zet$,
+  $(\zet,\etop s,!)$ together with $q_{i,n}$ yields, by the universal
+  property of $\Sc$, an element $(c,!,Q_{i,n})$ of $F_m$, and the
+  analysis of step 1 ensures that they are the only ones.
+
+  {\sc Step 3.} Let us then define $\myq: \bn m \to F_m$ by mapping
+  $i \mapsto (c,!,Q_{i,0})$. The claim is that $\myq$ is an
+  equivalence. Recall that $\Sc \equiv C$ is a subtype of $\Sc \to C$,
+  so that $F_m$ is a subtype of
+  \begin{displaymath}
+    \overline {F_m} \defequi \sum_{t:\Sc \to C}\blank^mc=_{\Sc\to C}\blank^mt
+  \end{displaymath}
+  If one denotes $\iota$ for the canonical inclusion
+  $F_m\mono \overline{F_m}$, then the contractibility of the fiber of
+  $\myq$ at a point $(t,!,Q):F_m$, is equivalent to the
+  contractibility of the fiber of $\iota\circ\myq$ at
+  $(t,Q):\overline{F_m}$ (by \cref{lem:subtype-eq-=}).  In other
+  words, one need to provide, for every $t:\Sc \to C$, an element of:
+  \begin{displaymath}
+    \prod_{Q:(\blank^mc=\blank^mt)} \iscontr(\inv {(\iota \myq)} (t,Q)) 
+  \end{displaymath}
+  Taking advantage of the equivalence
+  $\ev_C: (\Sc \to C) \weq \sum_{x:C}(x=_Cx)$ once again, this is
+  equivalent as to provide, for every $x:C$, an element of:
+  \begin{displaymath}
+    P(x) \defequi \prod_{p:x=_Cx}
+    \left(
+      \prod_{Q:(\blank^mc=\blank^m\ve_C(x,p))} \iscontr(\inv {(\iota \myq)} (\ve_C(x,p),Q))
+    \right) 
+  \end{displaymath}
+  Because $\iscontr(\blank)$ is valued in propositions, then so is
+  $P$. Through \cref{xca:component-connected} and because $C$ is
+  connected, one needs to check $P$ on only one point. We choose to do
+  so on $\pt_C$. Now, given $p:\pt_C = \pt_C$ and
+  $Q:(\blank^mc=\blank^m\ve(\pt_c,p))$, step 1 proves that
+  $(\etop s, !,!)=p$, so that in particular one has
+  $\pi:c=\ve(\pt_C,p)$, and then step 2 ensures that $Q_{i,n}=_\pi Q$
+  for some $(i,n):\bn m \times \zet$. Also notice that if one denotes
+  $\sigma_n:c = c$ for the path induced by $(\etop s^n,!,!): \pt_C=\pt_C$,
+  then it holds that $Q_{i,0}=_{\sigma_n}Q_{i,n}$: indeed the
+  transport along $\etop s^n$ (in the type family
+  $X \mapsto (\bn m\times \zet = \bn m\times X)$) is just the
+  postcomposition with $\id \times \etop s^n$, and
+  \begin{displaymath}
+    \begin{split}
+      (\id\times s^n) q_{i,0} = \sqrt[m]s^{nm}q_{i,0} &= ((j,z)\mapsto \sqrt[m]s^{nm+j+zm}(i,0))\\
+      &= ((j,z)\mapsto \sqrt[m]s^{j+zm}(i,n)) \\
+      &= q_{i,n}
+    \end{split}
+  \end{displaymath}
+  The compositions of the paths described above yield a path
+  $\pi\sigma_n: c = \ve_C(\pt_C,p)$ and a path-over
+  $Q_{i,0} =_{\pi\sigma_n} Q$, so that $(i,(\pi\sigma_n,!))$ is in the
+  fiber of $\iota\myq$ at $\ve_C(\pt_C,p)$. We claim it is a center of
+  contraction. Indeed, for any other $j:\bn m$ together with a path
+  $\rho:c=\ve_C(\pt_C,p)$ such that $Q_{j,0}=_\rho Q$, one gets
+  $Q_{i,0}=_{\inv \rho \pi\sigma_n}Q_{j,0}$. \cref{lem:IdCisZet} show
+  that $\inv\rho\pi\sigma_n = \sigma_k$ for some $k:\zet$ and the
+  previous path-over between $Q_{i,0}$ and $Q_{j,0}$ then means that
+  $(\id \times s^k)q_{i,0}=q_{j,0}$ which evaluated at
+  $(0,0):\bn m\times Z$ gives the equations $i=j$ and $k=0$. Hence
+  $(j,(\rho,!)) = (i,(\pi\sigma_n,!))$, concluding thus the proof that
+  $(i,(\pi\sigma_n,!))$ is a center of contraction for the fiber at
+  play.
+
+  % ((this does most of what is needed for the $m$-fold \covering.  Needs to be proofread))
+%     Let $m$ be a positive integer.  
+% Recall the $m$-fold \covering, either in the guise $-^m:\Sc\to \Sc$ of \cref{exa:mfoldS1cover} or $-^m:C\to C$ of \cref{exa:mfoldCcover}.
+% We are going to investigate the set
+% $$D_m\defequi\sum_{g:\Sc=\Sc}-^mg=_{\Sc\to \Sc}-^m$$  
+% of symmetries of the $m$-fold \covering of the circle.  
+% By univalence and thanks to the equivalence $c:\Sc\to C$ of \cref{thm:S1bysymmetries} $(\Sc= \Sc)$ is equivalent to $(\Sc\simeq C)$.
+% Since being contractible is a proposition, $\Sc\simeq C$ is a subtype of $\Sc\to C$,
+% which by \cref{lem:freeloopspace} is ultimately equivalent to $\sum_{(Y,g,!):C}(Y,g,!)=(Y,g,!)$. 
+% For the moment we'll investigate the simpler type 
+% $$F_m\defequi\sum_{t:\Sc\to C}-^mt=_{\Sc\to C}-^mc$$
+% and on the way discover that if $(t,Q):F_m$, then $t$ is an equivalence, so that $F_m$ actually {\bf is} equivalent to the type $D_m$ we are interested in.
+
+% Given If $t:\Sc\to C$ is given by $t(\base)\defequi (Y,g,!)$ (where $!$ asserts that $(Y,g)$ lies in the component of $(\zet,s)$)  and $t(\Sloop)=(p,!,!):(Y,g,!)=_C(Y,g,!)$, (where $p:Y=Y$ and $pg=gp$ (an identity in the set $Y=Y$)), we study the type $-^mt=_{\Sc\to C}-^mc$.
+% Spelling out the details we see that $-^mc$ is defined by 
+% $$-^mc(\base)=(\bn m\times\zet,\sqrt[m]s,!)$$ and 
+% $$-^mc(\Sloop)\defequi(\id\times s,!,!):(\bn m\times\zet,\sqrt[m]s,!)=_C(\bn m\times\zet,\sqrt[m]s,!)$$   and $-^mt$ is given by $$-^mt(\base)\oldequiv(\bn m\times Y,\sqrt[m]g,!)$$ and 
+% $$-^mt(\Sloop)\oldequiv(\id\times p,!,!):(\bn m\times Y,\sqrt[m]g,!)=_C(\bn m\times Y,\sqrt[m]g,!).$$
+
+% An element in $Q:-^mc=-^mt$ is then given by a 
+% $$q:\bn m\times\zet=\bn m\times Y$$ so that $\sqrt[m]g\ q=q\sqrt[m]s$ and $q(\id\times s)=(\id\times p)q$ (both in $\bn m\times\zet=\bn m\times Y$). 
+% Now, the element $$q^{-1}(\id\times s)q=q^{-1}(\sqrt[m]s)^mq=(q^{-1}\sqrt[m]sq)^m$$ in $\bn m\times Y=\bn m\times Y$ is both equal to $\id\times p$ and equal to $(\sqrt[m]g)^m=\id\times g$, proving that $p=g$. 
 
 
-Consider another element $(t',Q'):F_m$ (as for $(t,Q)$, we spell out $(t',Q')$ in terms of its accompanying $Y'$, $g'$ and $q'$). 
-An identity  $R:(t,Q)=_{F_m}(t',Q')$ consists of a $\rho:t=t'$ and an $s:(-^m\rho)Q=_{-^mc=-^mt'}Q'$ (note that this is a proposition), \ie $R$ is given by an $r:Y=Y'$ with 
-$$g'r=_{Y=Y'}rg\text{ and }(\id\times r)q=_{\bn m\times Y=\bn m\times Y'}q'(\id\times r).$$  This shows that every $(t,Q):F_m$ is equal to one with $(Y,g)$ being $(\zet,s)$ and $p$ being $s$, and we \emph{could} reduce to this case, leaving to $q$ the entire burden of proof.  
-This also shows another thing: the $t:\Sc\to C$ fitting in pairs $(t,Q):F_m$ are all equivalences, so that $F_m$ actually is equivalent to the type $\sum_{g:C=C}-^mg=_{C\to C}-^m$ we are trying to understand.
+% Consider another element $(t',Q'):F_m$ (as for $(t,Q)$, we spell out $(t',Q')$ in terms of its accompanying $Y'$, $g'$ and $q'$). 
+% An identity  $R:(t,Q)=_{F_m}(t',Q')$ consists of a $\rho:t=t'$ and an $s:(-^m\rho)Q=_{-^mc=-^mt'}Q'$ (note that this is a proposition), \ie $R$ is given by an $r:Y=Y'$ with 
+% $$g'r=_{Y=Y'}rg\text{ and }(\id\times r)q=_{\bn m\times Y=\bn m\times Y'}q'(\id\times r).$$  This shows that every $(t,Q):F_m$ is equal to one with $(Y,g)$ being $(\zet,s)$ and $p$ being $s$, and we \emph{could} reduce to this case, leaving to $q$ the entire burden of proof.  
+% This also shows another thing: the $t:\Sc\to C$ fitting in pairs $(t,Q):F_m$ are all equivalences, so that $F_m$ actually is equivalent to the type $\sum_{g:C=C}-^mg=_{C\to C}-^m$ we are trying to understand.
 
- On the level of equivalences $\zet\simeq Y$, the equation  $\sqrt[m]g\ q=q\sqrt[m]s$ claims that providing $q$ is the same as providing a point $q(0,0):Y$ through the equation  
-$$q(i,n)=q((\sqrt[m]s)^{i+nm}(0,0))=(\sqrt[m]g)^{i+nm}q(0,0).$$  For $(i,k)\in \bn m\times\zet$ define $Q^{(i,k)}$ by setting its first projection to be $q^{(i,k)}=(\sqrt[m]g)^{i+km}q$.  
-This exhausts all possible $q(0,0):Y$, so we have accounted for all possible $Q$s.
+%  On the level of equivalences $\zet\simeq Y$, the equation  $\sqrt[m]g\ q=q\sqrt[m]s$ claims that providing $q$ is the same as providing a point $q(0,0):Y$ through the equation  
+% $$q(i,n)=q((\sqrt[m]s)^{i+nm}(0,0))=(\sqrt[m]g)^{i+nm}q(0,0).$$  For $(i,k)\in \bn m\times\zet$ define $Q^{(i,k)}$ by setting its first projection to be $q^{(i,k)}=(\sqrt[m]g)^{i+km}q$.  
+% This exhausts all possible $q(0,0):Y$, so we have accounted for all possible $Q$s.
 
-However, there is some redundancy: since $(\sqrt[m]g)^{i+km}=(\sqrt[m]g)^i(\id\times g^k)$, we have that $g^k:Y=Y$ proves that $Q^{i+km}=Q^{i}$.  ((explain why there is no more redundancy)) 
+% However, there is some redundancy: since $(\sqrt[m]g)^{i+km}=(\sqrt[m]g)^i(\id\times g^k)$, we have that $g^k:Y=Y$ proves that $Q^{i+km}=Q^{i}$.  ((explain why there is no more redundancy)) 
 
-In hindsight we can give concrete descriptions of all the symmetries: for $i=0,\dots m-1$, let $(Y,g)\defequi (\zet,s)$, $p\defequi s$, and $q(0,0)\defequi i$.
+% In hindsight we can give concrete descriptions of all the symmetries: for $i=0,\dots m-1$, let $(Y,g)\defequi (\zet,s)$, $p\defequi s$, and $q(0,0)\defequi i$.
 
-With respect to the identification of the component of the $m$-fold covering.  The type of coverings of the circle is equivalent to $\sum_{X:\Set}X=X$ and by the above, the \covering being in the component of the $m$-fold cover corresponds to $(X,p)$ being in the component of $\zet/m$.
+% With respect to the identification of the component of the $m$-fold covering.  The type of coverings of the circle is equivalent to $\sum_{X:\Set}X=X$ and by the above, the \covering being in the component of the $m$-fold cover corresponds to $(X,p)$ being in the component of $\zet/m$.
   \end{proof}
 
   \begin{remark}

--- a/circle.tex
+++ b/circle.tex
@@ -1210,82 +1210,107 @@ The situation can be depicted as
 $$\xymatrix{A\ar@{=}[rr]^{p_A}_\to\ar[dr]_f&&A'\ar[dl]^{f'}\\&\,B.&}$$
 \end{remark}
 
-We start by investigating the symmetries of the universal \covering of the circle,
-since this case is simpler than that of the $m$-fold \coverings.
-Some easy observations will pave the way. 
+% We start by investigating the symmetries of the universal \covering of the circle,
+% since this case is simpler than that of the $m$-fold \coverings.
+% Some easy observations will pave the way. 
 
-First, for any types $X,Y$ 
-define $C_{Y,X} : X\to (Y\to X)$ to map any $x:X$ to the map $Y\to X$
-that is constant $x$, that is, $C_{Y,X}(x)\defeq c_x$.
-%We may leave out the subscripts of the map $C$. (confusion with type C)
-Clearly, $C_{\bn{1},X}$ is an equivalence from $X$ to $\bn{1}\to X$,
-which induces an equivalence from $x=x$ to $C_{Y,X}(x) = C_{Y,X}(x)$
-for any $x:X$.
+% First, for any types $X,Y$ 
+% define $C_{Y,X} : X\to (Y\to X)$ to map any $x:X$ to the map $Y\to X$
+% that is constant $x$, that is, $C_{Y,X}(x)\defeq c_x$.
+% %We may leave out the subscripts of the map $C$. (confusion with type C)
+% Clearly, $C_{\bn{1},X}$ is an equivalence from $X$ to $\bn{1}\to X$,
+% which induces an equivalence from $x=x$ to $C_{Y,X}(x) = C_{Y,X}(x)$
+% for any $x:X$.
 
-Second, we have by UA that $\bn{1}=\bn{1}$ is contractible
-and mapping $e: f=g$ to $(\refl{\bn{1}},e)$ is a equivalence from 
-$f=g$ to $\sum_{i:\bn{1}=\bn{1}} (\pathover{f}{\_\mapsto X}{i}{g})$ 
-for all $f,g:\bn{1}\to X$.
+% Second, we have by UA that $\bn{1}=\bn{1}$ is contractible
+% and mapping $e: f=g$ to $(\refl{\bn{1}},e)$ is a equivalence from 
+% $f=g$ to $\sum_{i:\bn{1}=\bn{1}} (\pathover{f}{\_\mapsto X}{i}{g})$ 
+% for all $f,g:\bn{1}\to X$.
 
-Third, we have the equivalence from \cref{lem:isEq-pair=}. 
-Combining these three equivalences in the special case of the point $\base:\Sc$ we get:
-\[
-(\base=\base) \equiv (c_\base=c_\base) \equiv
-\sum_{i:\bn{1}=\bn{1}} (\pathoverdisplay{c_\base}{\_\mapsto \Sc}{i}{c_\base}) \equiv 
-((\bn{1},c_\base)=_{\hat\Sc}(\bn{1},c_\base)).
-\]
-The trace is $p \mapsto \ap{C_{\bn{1},X}}(p) \mapsto 
-(\refl{\bn{1}},\ap{C_{\bn{1},X}}(p)) \mapsto \pathpair{\refl{\bn{1}}}{\ap{C_{\bn{1},X}}(p)}$.
-Applying this trace with $p\defeq\Sloop$ we obtain an additive unit for
-all these types that are equivalent to $\zet$.
-
- 
-
+% Third, we have the equivalence from \cref{lem:isEq-pair=}. 
+% Combining these three equivalences in the special case of the point $\base:\Sc$ we get:
+% \[
+% (\base=\base) \equiv (c_\base=c_\base) \equiv
+% \sum_{i:\bn{1}=\bn{1}} (\pathoverdisplay{c_\base}{\_\mapsto \Sc}{i}{c_\base}) \equiv 
+% ((\bn{1},c_\base)=_{\hat\Sc}(\bn{1},c_\base)).
+% \]
+% The trace is $p \mapsto \ap{C_{\bn{1},X}}(p) \mapsto 
+% (\refl{\bn{1}},\ap{C_{\bn{1},X}}(p)) \mapsto \pathpair{\refl{\bn{1}}}{\ap{C_{\bn{1},X}}(p)}$.
+% Applying this trace with $p\defeq\Sloop$ we obtain an additive unit for
+% all these types that are equivalent to $\zet$.
+Recall that for any type $X$ and element $x:X$, $\cst x$ denotes the
+function $\bn 1\to X$ defined by $\cst x (\ast) \defequi x$ on the
+unique element $\ast: \bn 1$. In particular,
+$\cst \base : \bn 1 \to \Sc$ denotes the universal \covering of $\Sc$.
 
 \begin{theorem}
   \label{thm:coveringsofS1}
   \begin{enumerate}
-  \item 
-  The set $c_\base=c_\base$ of symmetries of the universal \covering of the circle is equivalent to $\zet$.  
-Furthermore, there is a symmetry $$Q^1:c_\base=c_\base$$ so that, considered as an element in $\sum_{X:\Set}X=X$ the pair $(c_\base=c_\base,Q^1)$ is equal to $(\zet,s)$.  
+  \item \label{item:univ-cover-Sc-Z}%
+    There is an equivalence
+    $\Sc \weq \conncomp {\SetBundle(\Sc)} {\cst \base}$ mapping
+    $\base$ to $(\cst \base, \trunc{\refl {\cst \base}})$.
+    
+%   The set $c_\base=c_\base$ of symmetries of the universal \covering of the circle is equivalent to $\zet$.  
+% Furthermore, there is a symmetry $$Q^1:c_\base=c_\base$$ so that, considered as an element in $\sum_{X:\Set}X=X$ the pair $(c_\base=c_\base,Q^1)$ is equal to $(\zet,s)$.  
 
-The component of the type of \coverings over the circle containing the universal \covering is equivalent to the circle via the map from $S^1$ sending $\base$ to $c_\base$ and $\Sloop$ to $Q^1$.
-\item For a positive integer $m$, the set $-^m=-^m$ of symmetries of the $m$-fold \covering of the circle is equivalent to $\bn m$.  
+% The component of the type of \coverings over the circle containing the universal \covering is equivalent to the circle via the map from $S^1$ sending $\base$ to $c_\base$ and $\Sloop$ to $Q^1$.
+%
+  \item For a positive integer $m$, the set $-^m=-^m$ of symmetries of
+    the $m$-fold \covering of the circle is equivalent to $\bn m$.
 
 Furthermore, there is a symmetry $$Q^1:-^m=-^m$$ so that considered as an element in $\sum_{X:\Set}X=X$ the pair $(-^m=-^m,Q^1)$ is equal to $\zet/m$ of \cref{def:Zetmodm}.
 
 The component of the type of \coverings over the circle containing the $m$-fold covering is equivalent to $$\sum_{X:\Set}\sum_{p:X=X}\Trunc{(X,p)=\zet/m}.$$
   \end{enumerate}
-
  \end{theorem}
 \begin{remark}\label{rem:thenonuniquenessofgeneratorsofmodulararithmetic1}
-  The symmetries called $Q^1$ in \cref{thm:coveringsofS1} are not uniquely determined by the stated property.  
-In the case of the universal \covering there are two candidates and for the $m$-fold \covering there are as many as there are positive integers less than $m$ that does not divide $m$.  
-This behavior has number theoretic consequences and origins and will be investigated further when we have the proper machinery to put it to good use.
+  The symmetries called $Q^1$ in \cref{thm:coveringsofS1} are not
+  uniquely determined by the stated property.  In the case of the
+  universal \covering there are two candidates and for the $m$-fold
+  \covering there are as many as there are positive integers less than
+  $m$ that does not divide $m$.  This behavior has number theoretic
+  consequences and origins and will be investigated further when we
+  have the proper machinery to put it to good use.
 \end{remark}
 
-  \begin{proof}
-  ((spell out $Q^1$))
-We are going to investigate the set 
-$$D_0\defequi\sum_{g:\bn 1=\bn 1}c_\bullet g=c_\bullet$$ 
-of symmetries of the universal \covering $c_\bullet$ of the circle.  
-Our preferred interpretation of $c_\bullet:\bn 1\to C$ is as the first projection from $P\defequi\sum_{(Y,g):C}(\zet,s)=(Y,g)$ to $C$, and the equivalence $c_{((\zet,s),\refl{})}:\bn 1\to P$. 
-More generally, for any type $A$ the function $A\to(\bn 1\to A)$ sending $a:A$ to the function $c_a$ sending the unique element in $\bn 1$ to $a$ is an equivalence, and if $A$ is contractible, then every $c_a$ is an equivalence.
+\begin{proof}
+  Let us first prove (\ref{item:univ-cover-Sc-Z}). Through
+  \cref{lem:S1-delooping}, it is enough to find an equivalence
+  $(\base = \base) \weq (\cst\base =_{\SetBundle(\Sc)} \cst\base)$
+  which preserves reflexivity and composition of paths. It is obtained
+  as the composition
+  \begin{displaymath}
+    \left(\base =_{\Sc} \base\right) \weq \left( \cst\base=_{\bn 1\to \Sc}\cst\base \right)
+    \weq \left( \cst\base =_{\SetBundle(\Sc)} \cst\base \right)
+  \end{displaymath}
+  where the first equivalence is given by induction on $\bn 1$ and
+  function extensionality, and the second one is mapping a path $e$ to
+  the path $(\refl{\bn 1}, e)$. Both equivalences clearly preserve
+  reflexivity paths and composition of paths, so does their
+  composition.
+  
+%   ((spell out $Q^1$))
+% We are going to investigate the set 
+% $$D_0\defequi\sum_{g:\bn 1=\bn 1}c_\bullet g=c_\bullet$$ 
+% of symmetries of the universal \covering $c_\bullet$ of the circle.  
+% Our preferred interpretation of $c_\bullet:\bn 1\to C$ is as the first projection from $P\defequi\sum_{(Y,g):C}(\zet,s)=(Y,g)$ to $C$, and the equivalence $c_{((\zet,s),\refl{})}:\bn 1\to P$. 
+% More generally, for any type $A$ the function $A\to(\bn 1\to A)$ sending $a:A$ to the function $c_a$ sending the unique element in $\bn 1$ to $a$ is an equivalence, and if $A$ is contractible, then every $c_a$ is an equivalence.
 
-   Consequently, $D_0$ is equivalent to
-$$\sum_{((Y,g),p):P}(\zet,s)=_C(Y,g)$$ 
-which can be rewritten as
-$$\sum_{(Y,g):C}((\zet,s)=_C(Y,g))\times((\zet,s)=_C(Y,g))
-$$
-For any $a,b:A$ the ``shear'' 
-$$\mathrm{shear}:((a=_Ab)\times(a=_Ab))\to((a=_Ab)\times(a=_Aa))$$ 
-given by $\mathrm{shear}(p,q)\defequi(p,q^{-1}p)$
-is an equivalence and so $D_0$ is equivalent to 
-$$\sum_{(Y,g):C}((\zet,s)=_C(Y,g))\times ((\zet,s)=_C(\zet,s)).
-$$
-Using the equivalence $\ev_0:((\zet,s)=_C(\zet,s))\equiv\zet$ of \cref{lem:IdCisZet}, this
- reduces to 
-$$D_0\simeq P\times\zet\simeq\zet.$$
+%    Consequently, $D_0$ is equivalent to
+% $$\sum_{((Y,g),p):P}(\zet,s)=_C(Y,g)$$ 
+% which can be rewritten as
+% $$\sum_{(Y,g):C}((\zet,s)=_C(Y,g))\times((\zet,s)=_C(Y,g))
+% $$
+% For any $a,b:A$ the ``shear'' 
+% $$\mathrm{shear}:((a=_Ab)\times(a=_Ab))\to((a=_Ab)\times(a=_Aa))$$ 
+% given by $\mathrm{shear}(p,q)\defequi(p,q^{-1}p)$
+% is an equivalence and so $D_0$ is equivalent to 
+% $$\sum_{(Y,g):C}((\zet,s)=_C(Y,g))\times ((\zet,s)=_C(\zet,s)).
+% $$
+% Using the equivalence $\ev_0:((\zet,s)=_C(\zet,s))\equiv\zet$ of \cref{lem:IdCisZet}, this
+%  reduces to 
+% $$D_0\simeq P\times\zet\simeq\zet.$$
     
 ((this does most of what is needed for the $m$-fold \covering.  Needs to be proofread))
     Let $m$ be a positive integer.  

--- a/macros.tex
+++ b/macros.tex
@@ -246,13 +246,15 @@
 \newcommand{\revers}{\mathit{r}}
 \newcommand{\twist}{\mathit{twist}}%loop in BC_2
 \newcommand{\Sc}{{S^1}}%the circle
-\newcommand{\sbt}{\begin{picture}(-1,1)(-1,-3)\circle*{2}\end{picture}}
-\newcommand{\base}{{\,\sbt\ }}%point in circle
+%\newcommand{\sbt}{\begin{picture}(-1,1)(-1,-3)\circle*{2}\end{picture}}%
+\newcommand{\sbt}{\tikz[anchor=base,baseline]{\node[scale=.7,inner
+    sep=0, outer sep=0, circle]%
+    {$\bullet$};}}%
+\newcommand{\base}{{\sbt}}%point in circle
 \newcommand{\uc}[1]{{I_{#1}}}%universal set bundle
 \newcommand{\Zloop}{\circlearrowleft} %was \mathrm{loop}}%MAB: loop TorZor
 \newcommand{\Sloop}{\circlearrowleft}%loop in circle
-\newcommand{\bn}[1]{\mathbf{#1}}
-\newcommand{\Eq}{\mathrm{Eq}}
+\newcommand{\bn}[1]{\mathbf{#1}} \newcommand{\Eq}{\mathrm{Eq}}
 \newcommand{\emptytype}{\emptyset}
 
 \newcommand{\etop}[1]{\bar {#1}}
@@ -260,6 +262,10 @@
 \newcommand{\cast}{\mathrm{cast}}
 \newcommand{\ua}{\mathrm{ua}}%univalence inverse
 \newcommand{\zet}{\mathrm{Z}}%the SET of integers
+
+\newcommand{\cst}[1]{\operatorname{\mathit{c}}_{#1}}%
+\newcommand{\weqto}{\xrightarrow{\sim}}%
+\newcommand{\conncomp}[2]{{#1_{\left(#2\right)}}}
 
 %% paths over paths
 

--- a/macros.tex
+++ b/macros.tex
@@ -265,7 +265,9 @@
 
 \newcommand{\cst}[1]{\operatorname{\mathit{c}}_{#1}}%
 \newcommand{\weqto}{\xrightarrow{\sim}}%
-\newcommand{\conncomp}[2]{{#1_{\left(#2\right)}}}
+\newcommand{\conncomp}[2]{{#1_{\left(#2\right)}}}%
+
+\newcommand{\blank}{{\_}}%
 
 %% paths over paths
 


### PR DESCRIPTION
This PR concerns thm 3.7.2 about the cyclic groups as deck groups of the circle.

It simplifies the proof for the universal cover and details the existing proof for the m-fold cover.