### PR TITLE
Editing chap4

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1,6 +1,7 @@
 \documentclass[a4,12pt]{amsbook}
 \input macros
 \usepackage{showlabels}
+\renewcommand{\showlabelfont}{\ttfamily\tiny}%
 \renewcommand{\thesection}{\thechapter.\arabic{section}} % this used to be in macros.tex, but it isn't compatible with the amsart document class
 
 \begin{document}

--- a/group.tex
+++ b/group.tex
@@ -413,27 +413,32 @@ by exactly the same procedure, completing the list.
 These properties of the identity type are bundled together in the concept of an abstract group, under the additional hypothesis that we are dealing with a set.
 
 \begin{definition}\label{def:abstractgroup}
+  %% local redefinition of \ref to nested item 
+  \makeatletter %
+  \renewcommand\p@enumii{}%
+  \makeatother%
   An \emph{abstract group} consists of the following data:
   \begin{enumerate}
   \item a set $S$ called the \emph{underlying set} of the abstract group;
   \item an element $e:S$ called the \emph{unit} or the \emph{neutral element};
-  \item a function ${\cdot}: S\to S\to S$ called the \emph{multiplication},
+  \item\label{struc:mult-op} a function ${\cdot}: S\to S\to S$ called the \emph{multiplication},
     taking two elements $g_1,g_2:S$ to their \emph{product} denoted by $g_1\cdot g_2:S$;
 \footnote{The types $S\to S\to S$ and $(S\times S)\to S$ are equivalent
 and will be used interchangeably.}
 \noindent The above data should satisfy the following properties, for all $g,g_1,g_2,g_3:S$ :
     \begin{enumerate}
-    \item %$e$ is a ``neutral element'':
+    \item\label{axiom:unit-laws} %$e$ is a ``neutral element'':
       $g\cdot e=e\cdot g=g$ called the \emph{unit laws};
-    \item %satisfying ``associativity'':
+    \item\label{axiom:ass-law} %satisfying ``associativity'':
       $g_1\cdot(g_2\cdot g_3)=(g_1\cdot g_2)\cdot g_3$ called the \emph{associativity law};
   \end{enumerate}
-  \item a function ${}^{-1}: S\to S$ called the \emph{inverse operation},
+  \item\label{struc:inv-op} a function ${}^{-1}: S\to S$ called the \emph{inverse operation},
     taking an element $g:S$ to its \emph{inverse} denoted by $g^{-1}$.
 
-\noindent Moreover, the inverse operation should satisfy the following property, for all $g:S$ :
+    \noindent Moreover, the inverse operation should satisfy the
+    following property, for all $g:S$ :
 \begin{enumerate}\setcounter{enumii}{2}
-    \item %inverse
+    \item\label{axiom:inv-law} %inverse
       $ e = g\cdot g^{-1}$ called the \emph{law of inverses}.
     \end{enumerate}
 %  \item %inverses:
@@ -442,63 +447,85 @@ and will be used interchangeably.}
 \end{definition} 
 
 \begin{remark}\label{rem:inverses-as-property}
-Instead of including the inverse operation as part (3) of the structure
-and assuming the property (c),
-some authors assume the existence of inverses as a property:
-\begin{quote}
-(d) for all $g:S$ there exists an $h:S$ such that $e = g \cdot h$.
-\end{quote}
-Using the properties (a) and (b) one easily proves that such inverses are unique.
-We will now compare (d) to (4) plus (c).
+  %% local redefinition of \ref to nested item 
+  \makeatletter % 
+  \renewcommand\p@enumii{}%
+  \makeatother%
+  Instead of including the inverse operation as part
+  (\ref{struc:inv-op}) of the structure and assuming the property
+  (\ref{axiom:inv-law}), some authors assume the existence of inverses
+  as a property:
+  \begin{enumerate}
+  \item[]\begin{enumerate}\setcounter{enumii}{3}%
+    \item\label{axiom:mere-inverse} for all $g:S$ there exists an
+      $h:S$ such that $e = g \cdot h$.
+    \end{enumerate}
+  \end{enumerate}
+  Using the properties (\ref{axiom:unit-laws}) and
+  (\ref{axiom:ass-law}) one easily proves that such inverses are
+  unique. We will now compare (\ref{axiom:mere-inverse}) to (\ref{struc:inv-op}) plus
+  (\ref{axiom:inv-law}).
 
-First, \cref{def:abstractgroup} requires that $S$ is a set.
-Consequently, the properties (a)--(c) are propositions.
-Property (d) instead of (4) plus (c) does not require the inverse operation 
-to be a function. 
+  First, \cref{def:abstractgroup} requires that $S$ is a set.
+  Consequently, the properties
+  (\ref{axiom:unit-laws})--(\ref{axiom:inv-law}) are propositions.
+  Property (\ref{axiom:mere-inverse}) instead of (\ref{struc:inv-op}) plus
+  (\ref{axiom:inv-law}) does not require the inverse operation to be a
+  function.
 
-Property (d) contains the quantification ``there exists''.
-The faithful translation of (d) into type theory would be with
-$\exists$, ``there merely exists'', see \cref{sec:prop-trunc}. 
-Under this translation, contrary to groups in ordinary mathematics, 
-it makes no sense, a priori, to talk
-about ``the inverse of $g$'' and about the law of inverses.
-Indeed, ``the inverse of $g$'' could only be mentioned when targeting
-a propositional goal. 
+  Property (\ref{axiom:mere-inverse}) contains the quantification
+  ``there exists''.  The faithful translation of
+  (\ref{axiom:mere-inverse}) into type theory would be with $\exists$,
+  ``there merely exists'', see \cref{sec:prop-trunc}.  Under this
+  translation, contrary to groups in ordinary mathematics, it makes no
+  sense, a priori, to talk about ``the inverse of $g$'' and about the
+  law of inverses.  Indeed, ``the inverse of $g$'' could only be
+  mentioned when targeting a propositional goal.
 
-However, the following lemma proves that we can define an inverse
-operation as in (4) satisfying (c) from a witness of (d).
-This means that, a posteriori, we \emph{can} talk about 
-``the inverse of $g$'' also if the goal is not a proposition. 
-We choose to include the inverse operation in the structure right from the start.
+  However, the following lemma proves that we can define an inverse
+  operation as in (\ref{struc:inv-op}) satisfying
+  (\ref{axiom:inv-law}) from a witness of (\ref{axiom:mere-inverse}).
+  This means that, a posteriori, we \emph{can} talk about ``the
+  inverse of $g$'' also if the goal is not a proposition.  We choose
+  to include the inverse operation in the structure right from the
+  start.
 \end{remark} 
 
 \begin{lemma}%
   \label{lem:group-inv-operation}%
   Given a set $S$ together with $e$ and $\cdot$ as in
-  \cref{def:abstractgroup} satifying the unit laws,
-  the associativity law, and property (d), there is a function
-  $\inv{}: S \to S$ having property (c) of an abstract group.
+  \cref{def:abstractgroup} satifying the unit laws, the associativity
+  law, and property (\ref{axiom:mere-inverse}), there is a function
+  $\inv{\blank}: S \to S$ having property (\ref{axiom:inv-law}) of an
+  abstract group.
 \end{lemma}
 
 \begin{proof}
   Consider the function $\mu: S \to (S \to S)$ defined as
-  $g\mapsto (h \mapsto h\cdot g)$. We claim that $\mu(g)$ is an
-  equivalence for any $g:S$. Indeed, given $x:S$, and when targeting
-  the proposition $\iscontr(\inv{\mu(g)}(x))$, one can assume the
-  existence of $h$ such that $h\cdot g = e$. Then
-  $(x\cdot h)\cdot g = x$ through the associativity and unit
-  laws. This produces a element $(x\cdot h,!)$ of the fiber
-  $\inv{\mu(g)}(x)$. For any other element $(y,!)$, we want to prove
-  $(x\cdot h,!) = (y,!)$ which is equivalent to $x\cdot h=y$. Because
-  the equation $y\cdot g = x$ implies that
-  $(y\cdot g) \cdot h = x \cdot h$, the associativity laws allow to
-  simply prove $g\cdot h = e$ to conclude: this is a proposition so we
-  can assume a $h':S$ such that $h'\cdot h = e$, and by multiplying by
-  $g$, one obtains $h' = g$; this yields the result, as now
-  $g\cdot h = h'\cdot h = e$. Denote $c_{g,x}$ for the center of
-  contraction of $\inv{\mu(g)}(x)$.
-
-  The wanted function $\inv\blank$ is then given by $g\mapsto c_{g,e}$.  
+  $g\mapsto (h \mapsto g\cdot h)$. We claim that the fiber
+  $\inv{\mu(g)}(e)$ is contractible. This is a proposition, hence to
+  prove it from (\ref{axiom:mere-inverse}), one can as well assume the
+  actual existence of $h$ such that $g\cdot h = e$. Then $(h,!)$ is an
+  element of the fiber $\inv{\mu(g)}(e)$. We will now prove that it is
+  a center of contraction. For any other element $(h',!)$, we want to
+  prove $(h,!) = (h',!)$ which is equivalent to the type $h=h'$. In
+  order to prove the latter, we show that $h$ is also an inverse on
+  the left of $g$, meaning that $h\cdot g=e$: this is again a
+  proposition so we can assume from (\ref{axiom:mere-inverse}) an
+  actual element $k:S$ such that $h\cdot k = e$, and by multiplying by
+  $g$ on the left, one obtains
+  \begin{displaymath}
+    k = (g\cdot h)\cdot k = g\cdot (h\cdot k) = g\cdot e = g.
+  \end{displaymath}
+  From there it follows that
+  \begin{displaymath}
+    h = h \cdot e = h \cdot (g\cdot h') = (h \cdot g) \cdot h' = e\cdot
+    h' = h'
+  \end{displaymath}
+  as required. Hence $\inv{\mu(g)}(e)$ is contractible with center
+  $c_g \defequi (h,!)$. This argument works for an arbitrary $g:S$,
+  hence we can craft the function $\inv\blank : g \mapsto c_g$. By
+  definition it satisfies the law of inverses (\ref{axiom:inv-law}).
 \end{proof}
 Now we can refer to $\inv g$ as {\em the inverse of $g$}, and to the
 equations $g\cdot g^{-1}= g^{-1}\cdot g=e$ as the \emph{law of
@@ -533,9 +560,10 @@ where $\inv\blank$ is constructed as above.
   that the unit behaves like a unit and that the multiplication is
   associative.
 
-  \cref{lem:group-inv-operation} then proves that the \emph{type $\typegroup^\abstr$ of abstract groups} is equivalent to
+  In other words, the \emph{type $\typegroup^\abstr$ of abstract
+    groups} is equivalent to
   \begin{displaymath}
-    \sum_{(M,e,\mu,!):\typemonoid} \sum_{\iota\colon M\to M} \prod_{g:M}(e=\mu(\iota(g))(g)).
+    \sum_{(M,e,\mu,!):\typemonoid} \sum_{\iota\colon M\to M} \prod_{g:M}(e=\mu(g)(\iota(g))).
   \end{displaymath}
 
   We will typically refer to a monoid as a triple $(M,e,\mu)$,
@@ -554,7 +582,7 @@ define an abstract group
 $$\abstr(G)\defequi (\pt_G=\pt_G,e,\cdot,{-}^{-1}).$$
   \end{lemma}
   \begin{proof}
-    The elements $p_1,\dots p_4$ of \cref{def:p1,def:p4,def:p3,xca:p2} show that all the relevant identity types (which are propositions since $A$ is a groupoid) are nonempty, as required.
+    The elements $p_1,\dots, p_4$ of \cref{def:p1,def:p4,def:p3,xca:p2} show that all the relevant identity types (which are propositions since $A$ is a groupoid) are nonempty, as required.
   \end{proof}
   \begin{definition}\label{def:abstrG}
     Given a group $G$, the abstract group $\abstr(G)$ of \cref{lem:idtypesgiveabstractgroups} is called the \emph{abstract group associated to $G$}.
@@ -567,7 +595,7 @@ $$\abstr:\typegroup\to\typegroup^\abstr$$
 is an equivalence.
 \end{remark}
 \begin{remark}
-  If $\mathcal G=(S,e,\mu,\iota)$ and $\mathcal G'=(S',e',\mu',\iota')$ are abstract groups, an element of the identity type $\mathcal G=\mathcal G'$ consists of quite a lot of information.  First and foremost, we need an identity $p:S=S'$ of sets, but from there on the information is a list of elements in propositions (this is more interesting for \inftygps).  An analysis shows that this list can be shortened to ``$e'=p(e)$ and $\mu'(p(s),p(t))=p(\mu(s,t))$''.  The most convenient way of obtaining such an identity is to dream up a function $f:S\to S'$ that preserve the group structure (\ie what will shortly be called an abstract homomorphism) and then show that $f$ is an equivalence and  under univalence gives rise to an identity.
+  If $\mathcal G=(S,e,\mu,\iota)$ and $\mathcal G'=(S',e',\mu',\iota')$ are abstract groups, an element of the identity type $\mathcal G=\mathcal G'$ consists of quite a lot of information.  First and foremost, we need an identity $p:S=S'$ of sets, but from there on the information is a list of elements in propositions (this is more interesting for \inftygps).  An analysis shows that this list can be shortened to ``$e'=p(e)$ and $\mu'(p(s),p(t))=p(\mu(s,t))$''.  The most convenient way of obtaining such an identity is to dream up a function $f:S\to S'$ that preserves the group structure (\ie what will shortly be called an abstract homomorphism) and then show that $f$ is an equivalence and  under univalence gives rise to an identity.
 \end{remark}
 \begin{xca}
   \label{xca:conj}
@@ -579,10 +607,14 @@ Without the demand that the underlying type of an abstract group or monoid is a 
   \end{remark}
 
   \begin{xca}
-    For an element $g$ in an abstract group $(S,e,\mu,\iota)$, prove that $e=g\cdot g^{-1}$ and $g=(g^{-1})^{-1}$ (for the machines among us: ``give an element in the proposition
-$\prod_S
-(e=\mu{}(g)(\iota{}(g)))\times
-(g=\iota{}(\iota{}(g)))$'').
+    For an element $g$ in an abstract group, prove that
+    $e=\inv g\cdot g$ and $g=(g^{-1})^{-1}$. In other words (for the
+    machines among us), given an abstract group $(S,e,\mu,\iota)$,
+    give an element in the proposition
+    \begin{displaymath}
+      \prod_{g:S} (e=\mu(\iota(g))(g))\times
+      (g=\iota(\iota(g))).
+    \end{displaymath}
   \end{xca}
   \begin{xca}\label{xca:typemonoidisgroupoid}
     Prove that the types of monoids and abstract groups are groupoids.
@@ -608,30 +640,100 @@ Hint: setting $a\cdot b\defequi \bar b*a$ gives you an abstract group from a she
 \label{sec:homomorphisms}
 
 
-The notion of a group homomorphism from $G=\aut_A(a)$ to $H=\aut_B(b)$ is simple: it is an function $f:A\to B$ that ``sends $a$ to $b$'', \ie together with an element $p:a=_Bf(b)$:
+The notion of a group homomorphism from $G=\aut_A(a)$ to $H=\aut_B(b)$
+is simple: it is a pointed function $A\ptdto B$, that is a function
+$f:A\to B$ that ``sends $a$ to $b$'', \ie together with an element
+$p:b=_Bf(a)$:
 \begin{definition}\label{def:grouphomomorphism}
-  The type of \emph{group homomorphisms} from $G:\typegroup$ to $H:\typegroup$ is defined to be
-$$\Hom(G,H)\defequi(BG\to_* BH),
+  The type of \emph{group homomorphisms} from $G:\typegroup$ to
+  $H:\typegroup$ is defined to be
+  $$\Hom(G,H)\defequi(\clf G\ptdto \clf H),
 %\footnote{would you be unhappy if I used $f:G\to_{\typegroup}H$ when it fits better with the typography?}%\sum_{f:A\to B}f(a)=_Bb.
 $$
-in other words, a homomorphism $f:\Hom(G,H)$ is a pair $(Bf_\div,p_f)$ where $Bf_\div:BG_\div\to BH_\div$ and $p_f:\pt_H=Bf_\div(\pt_G)$.
+in other words, a homomorphism $f:\Hom(G,H)$ is a pair $({\clf f}_\div,p_f)$ where ${\clf f}_\div:{\clf G}_\div\to {\clf H}_\div$ and $p_f:\pt_H={\clf f}_\div(\pt_G)$.
 \end{definition}
-When there is little danger of confusion we may drop the subscript $\div$ even when talking about the unpointed structure.
-\begin{example}
+When there is little danger of confusion we may drop the subscript
+$\div$ even when talking about the unpointed structure.
+\begin{example}%
+  \label{ex:groups-morphisms}%
+  ~%
   \begin{enumerate}
-  \item   Consider two sets $S$ and $T$.  
-Recall that $\Set_{(S)}\defequi\sum_{X:\Set}\Trunc{S=X}$ is the component of the groupoid $\Set$ containing $S$, and when pointed at $S$ represents the permutation group $\Sigma_S$.  
-The map $\Set_{(S)}\to\Set_{(S\coprod T)}$ sending $X$ to $X\coprod T$ induces a group homomorphism $\Sigma_S\to\Sigma_{S\coprod T}$.
-Thought of as symmetries, this says that if you have a symmetry of $S$, then we get a symmetry on $S\coprod T$ (which doesn't do anything to $T$).  
+  \item Consider two sets $S$ and $T$.  Recall from \cref{ex:groups}
+    that $\Set_{(S)}\defequi\sum_{X:\Set}\Trunc{S=X}$ is the component
+    of the groupoid $\Set$ containing $S$, and when pointed at $S$
+    represents the permutation group $\Sigma_S$.  The map
+    $\blank\coprod T:\Set_{(S)}\to\Set_{(S\coprod T)}$ sending $X$ to $X\coprod T$
+    induces a group homomorphism $\Sigma_S\to\Sigma_{S\coprod T}$,
+    pointed by the path $\refl {S\coprod T}:S\coprod T = (\blank\coprod T)(S)$.
+    Thought of as symmetries, this says that if you have a symmetry of
+    $S$, then we get a symmetry on $S\coprod T$ (which doesn't do
+    anything to $T$).
 
-Likewise, we get a map $\Set_{(S)}\to\Set_{(S\times T)}$ sending $X$ to $X\times T$ induces a group homomorphism $\Sigma_S\to\Sigma_{S\times T}$. 
+    Likewise, we get a map
+    $\blank\times T:\Set_{(S)}\to\Set_{(S\times T)}$ sending $X$ to
+    $X\times T$ induces a group homomorphism
+    $\Sigma_S\to\Sigma_{S\times T}$, pointed by the path
+    $\refl {S\times T}: {S\times T} = (\blank \times T)(S)$.
 
 In particular, we get homomorphisms $\Sigma_m\to\Sigma_{m+n}$ and $\Sigma_m\to\Sigma_{mn}$. \footnote{find a good description of the sign $\Sigma_n\to\Sigma_2$}
-\item Let $G$ be a group.  Since there is a unique map from $BG$ to $\bn{1} $, we get a unique homomorphism from $G$ to the trivial group.  
-Likewise, there is a unique morphism from the trivial group to $G$, sending the unique element of $\bn 1$ to $\pt_G$. 
+\item Let $G$ be a group.  Since there is a unique map from $BG$ to
+  $\bn{1} $ (obviously pointed by the reflexivity path of the unique
+  element of $\bn 1$), we get a unique homomorphism from $G$ to the
+  trivial group.  Likewise, there is a unique morphism from the
+  trivial group to $G$, sending the unique element of $\bn 1$ to
+  $\pt_G$, and pointed by $\refl {\pt_G}$.
 \item If $G$ and $H$ are groups, the inclusions and projections between $B(G\times H)\oldequiv BG\times BH$ and $BG$ and $BH$ give rise to group homomorphisms between $G\times H$ and $G$ and $H$.  \footnote{Elaborate}
   \end{enumerate}
 \end{example}
+
+\begin{remark}
+  In the last examples, we insisted on the path pointing a group
+  homomorphism even when this path was a reflexivity path. We now take
+  the convention to not specify the path in this case. Thus, given
+  $f:A \to B$ is a map between connected groupoids and $a:A$, the
+  group homomorphism $\Aut_A(a) \to \Aut_B(f(a))$ defined
+  $(f,\refl{f(a)})$ will simply be referred by $f$.
+
+  However, it is important to understand that different homomorphisms
+  can have the same underlying unpointed function. Consider, for
+  example, the group $\permgrp 3$ and the path
+  $\tau:\pt_{\permgrp 3}=\pt_{\permgrp 3}$ that is defined (through
+  univalence) as
+  \begin{displaymath}
+    0\mapsto 1,\quad 1\mapsto 0,\quad 2 \mapsto 2 
+  \end{displaymath}
+  Then the function $\id: \fin_3 \to \fin_3$ gives rise to two
+  elements of $\Hom(\permgrp 3,\permgrp 3)$: the first one is
+  $(\id,\refl{\bn 3})$, which is simply denoted $\id_{\permgrp 3}$;
+  the second one is $(\id,\tau)$, that we will denote $\tilde\tau$
+  temporarily. Let us prove $\id_{\permgrp 3} \neq \tilde \tau$, that
+  is suppose a path $\id_{\permgrp 3}= \tilde \tau$ and derive a
+  contradiction. Such a path is the data of a path $p:\id = \id$ such
+  that $\pathover {\refl{\bn 3}} {T} {p} \tau$ where the type family
+  $T:(\fin_3\to\fin_3) \to \UU$ is given by
+  $f\mapsto \pt_{\permgrp 3} = f(\pt_{\permgrp 3})$. It is easy to
+  determine the transport in that type family $T$ and we find that
+  $(\pathover {\refl{\bn 3}} {T} {p} \tau) \weq (p(\pt_{\permgrp
+    3})=\tau)$. Now, by induction on $q:\id=f$ for
+  $f:\permgrp 3 \to \permgrp 3$, one shows that
+  \begin{displaymath}
+    \ap f : (\pt_{\permgrp 3} = \pt_{\permgrp 3}) \to
+    (f(\pt_{\permgrp 3}) = f(\pt_{\permgrp 3}))
+  \end{displaymath}
+  is equal to
+  $q(\pt_{\permgrp 3})\cdot {\blank}\cdot \inv{q(\pt_{\permgrp
+      3})}$. In particular, when $f\jdeq \id$ and $q\jdeq p$, it means
+  that conjugating by $p(\pt_{\permgrp 3})$ is trivial. But by
+  hypothesis $p(\pt_{\permgrp 3}) = \tau$, so it means that $\tau$
+  commutes with every other element of
+  $\pt_{\permgrp 3} = \pt_{\permgrp 3}$. One can check that it
+  actually fails to be the case for the element $\theta$ defined by
+  \begin{displaymath}
+    0\mapsto 0,\quad 1\mapsto 2,\quad 2\mapsto 1 .
+  \end{displaymath}
+  Indeed, $\theta\tau(0) = 2$ while $\tau\theta(0) = 1$.
+\end{remark}
+
 \begin{example}
   \label{ex:Zinitial}
   \cref{cha:circle} was all about the circle $S^1$ and its role as a ``universal symmetry'' and how it related to the integers.  

--- a/group.tex
+++ b/group.tex
@@ -689,10 +689,10 @@ In particular, we get homomorphisms $\Sigma_m\to\Sigma_{m+n}$ and $\Sigma_m\to\S
 \begin{remark}
   In the last examples, we insisted on the path pointing a group
   homomorphism even when this path was a reflexivity path. We now take
-  the convention to not specify the path in this case. Thus, given
-  $f:A \to B$ is a map between connected groupoids and $a:A$, the
-  group homomorphism $\Aut_A(a) \to \Aut_B(f(a))$ defined
-  $(f,\refl{f(a)})$ will simply be referred by $f$.
+  the convention to not specify the path in this case. Thus, given a
+  map $f:A \to B$ between connected groupoids and $a:A$, the group
+  homomorphism $\Aut_A(a) \to \Aut_B(f(a))$ defined by
+  $(f,\refl{f(a)})$ will simply be referred to as $f$.
 
   However, it is important to understand that different homomorphisms
   can have the same underlying unpointed function. Consider, for

--- a/group.tex
+++ b/group.tex
@@ -696,7 +696,8 @@ In particular, we get homomorphisms $\Sigma_m\to\Sigma_{m+n}$ and $\Sigma_m\to\S
 
   However, it is important to understand that different homomorphisms
   can have the same underlying unpointed function. Consider, for
-  example, the group $\permgrp 3$ and the path
+  example, the group $\permgrp 3$, whose classifying space is
+  $\clf \permgrp 3\defequi (\fin_3,\bn 3)$, and the path
   $\tau:\pt_{\permgrp 3}=\pt_{\permgrp 3}$ that is defined (through
   univalence) as
   \begin{displaymath}
@@ -711,7 +712,7 @@ In particular, we get homomorphisms $\Sigma_m\to\Sigma_{m+n}$ and $\Sigma_m\to\S
   contradiction. Such a path is the data of a path $p:\id = \id$ such
   that $\pathover {\refl{\bn 3}} {T} {p} \tau$ where the type family
   $T:(\fin_3\to\fin_3) \to \UU$ is given by
-  $f\mapsto \pt_{\permgrp 3} = f(\pt_{\permgrp 3})$. It is easy to
+  $f\mapsto (\pt_{\permgrp 3} = f(\pt_{\permgrp 3}))$. It is easy to
   determine the transport in that type family $T$ and we find that
   $(\pathover {\refl{\bn 3}} {T} {p} \tau) \weq (p(\pt_{\permgrp
     3})=\tau)$. Now, by induction on $q:\id=f$ for
@@ -731,51 +732,96 @@ In particular, we get homomorphisms $\Sigma_m\to\Sigma_{m+n}$ and $\Sigma_m\to\S
   \begin{displaymath}
     0\mapsto 0,\quad 1\mapsto 2,\quad 2\mapsto 1 .
   \end{displaymath}
-  Indeed, $\theta\tau(0) = 2$ while $\tau\theta(0) = 1$.
+  Indeed, $\theta\tau(0) = 2$ while $\tau\theta(0) = 1$. (See also
+  \cref{exer:first examples}.)
 \end{remark}
 
 \begin{example}
   \label{ex:Zinitial}
-  \cref{cha:circle} was all about the circle $S^1$ and its role as a ``universal symmetry'' and how it related to the integers.  
-In our current language, $\ZZ\defequi\aut_{S^1}(\base)$ and large parts of the universality is found in the following observation. 
-If $G$ is a group then the evaluation equivalence $\ev_{BG_\div}:(S^1\to BG_\div)\we \sum_{y:BG}(y=y)$ of \cref{lem:freeloopspace} yields an equivalence 
-$$\ev_{BG}:\Hom(\ZZ,G)\defequi((S^1,\base)\to_*BF)\we (\pt_G=\pt_G).$$
-
-  %Show that ((wedges of circle vs multiplication))
+  \cref{cha:circle} was all about the circle $S^1$ and its role as a
+  ``universal symmetry'' and how it related to the integers.  In our
+  current language, $\ZZ\defequi\aut_{S^1}(\base)$ and large parts of
+  the universality is found in the following observation.  If $G$ is a
+  group then the evaluation equivalence
+  $\ev_{BG_\div}:(S^1\to BG_\div)\we \sum_{y:BG_\div}(y=y)$ of
+  \cref{lem:freeloopspace} yields an equivalence
+  $$\ev_{BG}:\left((S^1,\base)\ptdto BG\right)\we (\pt_G=\pt_G).$$
+  The domain of this equivalence $\ev_{BG}$ is nothing else that the
+  definition of $\Hom(\ZZ,G)$. Hence, $\ev_{BG}$ provides a way to
+  identify $\Hom(\ZZ,G)$ with the abstract group $\pt_G=\pt_G$.
+  % Show that ((wedges of circle vs multiplication))
 \end{example}
 \begin{example}
-  We will later show that if $G$ and $H$ are groups, then $\Hom(G,H)$ is equivalent to the {\bf set} of ``abstract group homomorphisms'' from $\abstr(G)$ to $\abstr(H)$, but it is instructive to see that 
-$$\Hom(G,H)\defequi(BG\to_*BH)\defequi\sum_{F:BG_\div\to BH_\div}(\pt_H=F(\pt_G))$$ 
-is a set directly from the definition.  Recall our notation; $f:\Hom(G,H)$ is recorded as the pair $(Bf_\div,p_f):\sum_{F:BG_\div\to BH_\div}(\pt_H=F(\pt_G))$.
+  We will later show that if $G$ and $H$ are groups, then $\Hom(G,H)$
+  is equivalent to the {\bf set} of ``abstract group homomorphisms''
+  from $\abstr(G)$ to $\abstr(H)$ (cf.\ \cref{lem:homomabstrconcr}),
+  but it is instructive to prove that
+  $$\Hom(G,H)\defequi(BG\ptdto BH)\defequi\sum_{F:BG_\div\to BH_\div}(\pt_H=F(\pt_G))$$ 
+  is a set directly from the definition. Recall our notation: a
+  homomorphism $f:\Hom(G,H)$ is recorded as the pair
+  \begin{displaymath}
+    (Bf_\div,p_f):\sum_{F:BG_\div\to BH_\div}(\pt_H=F(\pt_G)).
+  \end{displaymath}
+  Let us spell out the data needed to give an identity between two
+  group homomorphisms $f,f':\Hom(G,H)$.  We clearly must have a
+  $$J:Bf_\div=Bf_\div',$$
+  which by function extensionality \cref{def:funext} is equivalently
+  uniquely given by its image given by the element (with the same
+  name) in the $\Pi$-type
+  $$J:\prod_{z:BG_\div}Bf_\div(z)=Bf'_\div(z).$$ 
+  Transport over $J$ of $p_f:\pt_H=Bf_\div(\pt_G)$ shows that in
+  addition we must have a path $!:J(\pt_G)\cdot p_f=p_{f'}$ in the
+  type ${\pt_H=Bf'_\div(\pt_G)}$:
+  \begin{displaymath}
+    \xymatrix{&\pt_H\ar@{=}[dl]_{p_f}^{\rotatebox{35}{\footnotesize$\gets$}}
+      \ar@{=}[dr]^{p_{f'}}_{\rotatebox{-35}{\footnotesize$\to$}}&\\
+      Bf_\div(\pt_G)\ar@{=}[rr]^{J(\pt_G)}_\to&&\,Bf'_\div(\pt_G).}
+  \end{displaymath}
+  In other words, we have an equivalence
+  $$(f=f')\simeq \sum_{J:Bf_\div=Bf'_\div}J(\pt_G)p_f=p_{f'}.$$
+  Now, take $(J,!)$ and $(K,!)$ of the latter type. Then
+  $(J,!) = (K,!)$ is equivalent to $J=K$, that is in turn equivalent
+  to $\prod_{z:BG_\div}J(z)=K(z)$. Because $Bf_\div(z)=Bf'_\div(z)$ is
+  a set for every $z$ ($BH_\div$ being a groupoid), the type
+  $J(z)=K(z)$ is a proposition. One can now use the connectedness of
+  $BG_\div$, and only check the equality on a given point, say
+  $\pt_G$. However, from the previous diagram, it follows that
+  \begin{displaymath}
+    J(\pt_G) = p_{f'}\inv{p_f} = K(\pt_G).
+  \end{displaymath}
+  This concludes the proof that $f=f'$ is a proposition, or in other
+  words that $\Hom(G,H)$ is a set.
 
-  Let us spell out the data needed to give an identity between two group homomorphisms $f,f':\Hom(G,H)$.  
-We clearly must have a
-$$J:Bf_\div=Bf_\div',$$
-which by function extensionality \cref{def:funext} is equivalently uniquely given by its image given by the element  (with the same name) in the $\Pi$-type
-$$J:\prod_{z:BG_\div}Bf_\div(z)=Bf'_\div(z).
-$$ 
-Transport on $\pt_H=Bf_\div(?)$ shows that in addition we must have $!:J(\pt_G)\,p_f=_{\pt_H=Bf'_\div(\pt_G)}p_{f'}$:
-$$\xymatrix{&\pt_H\ar@{=}[dl]_{p_f}^\gets\ar@{=}[dr]^{p_{f'}}_\to&\\
-Bf_\div(\pt_G)\ar@{=}[rr]^{J(\pt_G)}_\to&&\,Bf_\div(\pt_G);}
-$$
-in other words, we have an equivalence
-$$(f=f')\simeq \sum_{J:Bf_\div=Bf'_\div}J(\pt_G)\,p_f=p_{f'}.
-$$
-Now, $J$ being member of a $\prod$-type implies that if $z:BG$ and $\gamma:\pt_G=z$, then $!:J(z)Bf_\div(\gamma)=Bf'_\div\gamma J(\pt_G)$
-$$\xymatrix{
-Bf_\div(\pt_G)\ar@{=}[r]^{J(\pt_G)}_\to\ar@{=}[d]^\downarrow_{Bf_\div\gamma}&
-Bf'_\div(\pt_G)\ar@{=}[d]^\downarrow_{Bf'_\div\gamma}\\
-Bf_\div(z)\ar@{=}[r]^{J(z)}_\to&Bf'_\div(z)},
-$$
-so that -- since $BG$ is connected and $Bf_\div(z)=Bf'_\div(z)$ is a set -- $J(z)$ is determined by $J(\pt_G)$ which again is determined by $p_f$ and $p_{f'}$.  
-This shows that $f=f'$ is a proposition and that $\Hom(G,H)$ is a set.
+  %% ---------------------------------------------------------------
+  %% P.Cagne (Feb. 20th 2020)
+  %%
+  %% We can roll back to this end of the proof but it uses loose
+  %% vocabulary ('is determined by') and it does not provide clear
+  %% propositional targets that would allow to use actual paths as
+  %% gamma instead of mere ones.
+  %%
+  %% (Unless I miss something of course, just tell me then.)
+  %% ---------------------------------------------------------------
+  %%
+  % Now, $J$ being member of a $\prod$-type implies that if $z:BG$ and
+  % $\gamma:\pt_G=z$, then $!:J(z)Bf_\div(\gamma)=Bf'_\div(\gamma) J(\pt_G)$
+  % $$\xymatrix{
+  %   Bf_\div(\pt_G)\ar@{=}[r]^{J(\pt_G)}_\to\ar@{=}[d]^\downarrow_{Bf_\div(\gamma)}&
+  %   Bf'_\div(\pt_G)\ar@{=}[d]^\downarrow_{Bf'_\div(\gamma)}\\
+  %   Bf_\div(z)\ar@{=}[r]^{J(z)}_\to&Bf'_\div(z)},
+  % $$
+  % so that -- since $BG$ is connected and $Bf_\div(z)=Bf'_\div(z)$ is a
+  % set -- $J(z)$ is determined by $J(\pt_G)$ which again is determined
+  % by $p_f$ and $p_{f'}$.  This shows that $f=f'$ is a proposition and
+  % that $\Hom(G,H)$ is a set.
 
 % We want to show that $f=f'$ is a proposition.  If $(J,!)$ and $(J',!)$ are elements in $\sum_{J:Bf_\div=Bf'_\div}J(\pt_G)\,p_f=p_{f'}$, then $!:J(\pt_G)=p_{f'}p_f^{-1}=J'(\pt_G)$.  Since $J(z)=J'(z)$ is a proposition for each $z:BG$ it suffices to display a map $(\pt_G=z)\to(J(z)=J'(z))$. 
 \end{example}
 
 
 \begin{xca}\label{xca:BGtotype}
-  Let $G$ be a group and $A$ a connected groupoid.  Use the definitions and \cref{xca:freemaps} to show that the types
+  Let $G$ be a group and $A$ a groupoid.  Use the definitions and
+  \cref{xca:freemaps} to show that the types
   \begin{enumerate}
   \item $BG_\div\to A$, 
   \item $\sum_{a:A}\sum_{f:BG_\div \to A}(f(\pt_G)=a)$, 
@@ -787,29 +833,48 @@ This shows that $f=f'$ is a proposition and that $\Hom(G,H)$ is a set.
 
 The definition of group homomorphisms in \cref{def:grouphomomorphism} should be contrasted with the usual -- and somewhat more cumbersome -- notion of a group homomorphism $f\colon \mathcal G\to \mathcal H$ of abstract groups where we must specify that in addition to preserving the neutral element ``$f(e_G)=e_H$'' it must preserve multiplication: ``$f(g)\cdot_{\mathcal H} f(g')=f(g\cdot_{\mathcal G} g')$ (where we have set the name of the abstract group as a subscript to $e$ and $\cdot$).  In our setup this is simply true:
 
-\begin{definition}\label{def:grouphomomaxioms}
-Let $G$ and $H$ be groups and assume given a group homomorphism $f:G\to H$.  We now define something that we will call an ``abstract group homomorphism 
-${\abstr}(f):\abstr(G)\to \abstr(H)$'', \ie a function of sets from $(\pt_G=\pt_G)$ to $(\pt_H=\pt_H)$ ``preserving'' the group structure, c.f~\cref{def:abstrG} for the definition of $\abstr(G)$ and \cref{def:abstrisfunctor} for a condensation of what the discussion below end up with concluding that ``preserves'' means.  
+\begin{remark}\label{def:grouphomomaxioms}
+  Let $G$ and $H$ be groups and assume given a group homomorphism
+  $f:G\to H$.  We now define something that we will later call an
+  ``abstract group homomorphism
+  ${\abstr}(f):\abstr(G)\to \abstr(H)$'', \ie a function of sets from
+  $(\pt_G=\pt_G)$ to $(\pt_H=\pt_H)$ ``preserving'' the abstract group
+  structure, cf.\ \cref{def:abstrG} for the definition of $\abstr(G)$
+  and \cref{def:abstrisfunctor} for a condensation of what the
+  discussion below end up with concluding that ``preserves'' means.
 
-We take the time to develop this from first principles.
-Recall that $f$ is nothing but a pointed function from $BG$ to $BH$; or in other words a map of (unpointed) types 
-$$Bf_\div\colon BG_\div\to BH_\div$$ 
-and an identity 
-$$p_f: Bf_\div(\pt_G)=\pt_H.$$  
-As in \cref{def:apd}%\footnote{I use $f(p)$ rather than the $\mathrm{ap}_f$-formalism which I think is alienating when compared with the classical setup}
-, for $z:BG$ this gives rise to a map 
-$$\ap{Bf_\div}:(\pt_G=z)\to (Bf_\div(\pt_G)=Bf_\div(z)),$$ 
-defined by induction by declaring that $\ap{Bf_\div}(\refl{\pt_G})\defequi \refl{Bf_\div(\pt_G)}$.  
-If $g:\pt_G=\pt_G$, then $\ap{Bf_\div}(g)$ is an element of $Bf_\div(\pt_G)=Bf_\div(\pt_G)$, while we want something in $\pt_H=\pt_H$.  However, this is not an obstacle since conjugation by $p_f: Bf_\div(\pt_G)=\pt_H$ gives rise to 
-$$\mathrm{ad}_{p_f}:(Bf_\div(\pt_G)=Bf_\div(\pt_G))=(\pt_H=\pt_H)$$ (with $\mathrm{ad}_{p_f}(\refl{Bf_\div(\pt_G)})=\refl{\pt_H}$, as discussed in \cref{sec:heavy-transport}) and so 
-$$\mathrm{ad}_{p_f}(\ap{Bf_\div}(g)):\pt_H=\pt_H.$$
-This defines a function
-$$f^\abstr\defequi \mathrm{ad}_{p_f}\ap{Bf_\div}:(\pt_G=\pt_G)\to(\pt_H=\pt_H)$$  
-and we depict $f^\abstr(g)$ as the ``up, over and down'' identity of $\pt_H$:
-$$\xymatrix{Bf_\div(\pt_G)\ar@{=}[r]^{\ap{Bf_\div}(g)}_\to\ar@{=}[d]^\downarrow_{p_f}&Bf_\div(\pt_G)\ar@{=}[d]^\downarrow_{p_f}\\
-\pt_H\ar@{:}[r]^{f^\abstr(g)}_\to&\,\pt_H.}$$
-
-
+  Recall that such a $f:\Hom(G,H)$ is recorded as a pair
+  \begin{displaymath}
+    (Bf_\div,p_f):\sum_{F:BG_\div\to BH_\div}(\pt_H=F(\pt_G)),
+  \end{displaymath}
+  and define the function
+  \begin{displaymath}
+    f^\abstr : (\pt_G=\pt_G) \xrightarrow{\ap {Bf_\div}}
+    (f(\pt_G)=f(\pt_G)) \xrightarrow{\trp {\inv{p_f}}} (\pt_H=pt_H)
+  \end{displaymath}
+  We take the time to develop from first principles the properties
+  that $f^\abstr$ satisfies.
+  % As in \cref{def:apd}%\footnote{I use $f(p)$ rather than the $\mathrm{ap}_f$-formalism which I think is alienating when compared with the classical setup}
+% , for $z:BG$ this gives rise to a map 
+% $$\ap{Bf_\div}:(\pt_G=z)\to (Bf_\div(\pt_G)=Bf_\div(z)),$$ 
+% defined by induction by declaring that $\ap{Bf_\div}(\refl{\pt_G})\defequi \refl{Bf_\div(\pt_G)}$.  
+% If $g:\pt_G=\pt_G$, then $\ap{Bf_\div}(g)$ is an element of $Bf_\div(\pt_G)=Bf_\div(\pt_G)$, while we want something in $\pt_H=\pt_H$.  However, this is not an obstacle since conjugation by $p_f: Bf_\div(\pt_G)=\pt_H$ gives rise to 
+% $$\mathrm{ad}_{p_f}:(Bf_\div(\pt_G)=Bf_\div(\pt_G))\weq(\pt_H=\pt_H)$$ (with $\mathrm{ad}_{p_f}(\refl{Bf_\div(\pt_G)})=\refl{\pt_H}$, as discussed in \cref{sec:heavy-transport}) and so 
+% $$\mathrm{ad}_{p_f}(\ap{Bf_\div}(g)):\pt_H=\pt_H.$$
+% This defines a function
+% $$f^\abstr\defequi \mathrm{ad}_{p_f}\ap{Bf_\div}:(\pt_G=\pt_G)\to(\pt_H=\pt_H)$$
+  One proves easily (by induction) that
+  $\trp {\inv{p_f}} = \inv{p_f} \cdot \blank \cdot p_f$. It means that
+  the element $f^\abstr(g)$ is the ``up, over and down'' identity of
+  $\pt_H$ depicted in the following diagram:
+  \begin{displaymath}
+    \xymatrix{%
+      Bf_\div(\pt_G)\ar@{=}[r]^{\ap{Bf_\div}(g)}_\to \ar@{=}[d]^\uparrow_{p_f} &
+      Bf_\div(\pt_G)\ar@{=}[d]^\uparrow_{p_f}
+      \\
+      \pt_H\ar@{:}[r]^{f^\abstr(g)}_\to & \pt_H.%
+    }
+  \end{displaymath}
 % Since type-checking removes the ambiguity, we trust it will not lead to any confusion that we simplify the notation and use the symbol $f$ simultaneously for $Bf_\div$, writing $f\colon BG_\div\to BH_\div$ and for $\ap{Bf_\div}$, writing $f:(\pt_G=\pt_G)\to (f(\pt_G)=f(\pt_G))$, while we write
 % $$f^\abstr\defequi \mathrm{ad}_p\ap{Bf_\div}:(\pt_G=\pt_G)\to(\pt_H=\pt_H), \qquad g\mapsto p\,f(g)\,p^{-1}$$  
 % and depicting it as the ``up, over and down'' identity of $\pt_H$:
@@ -822,50 +887,72 @@ With the shorthand $$e_G\defequi\refl{\pt_G}:(\pt_G=\pt_G)$$ and writing (to rem
 $$g\cdot_Gg':(\pt_G=\pt_G)$$
  for the composite $g\,g'$ of $g$ and $g'$ (note that we use functional notation, so that composition is ``first $g'$ and then $g$'' as in the picture 
 $\xymatrix{\pt_G\ar@{=}[r]^{g'}_\to&\pt_G\ar@{=}[r]^{g}_\to&\pt_G}$) %$\trans_{\pt_G,\pt_G\pt_G}(g,g'):$ 
-and likewise with a subscript $H$, we have the following
+and likewise with a subscript $H$, we have the following:
   \begin{enumerate}
-  \item $\refl{e_H}:f^\abstr(e_G)= e_H$ makes sense since
-$$f^\abstr(e_G)\defequi\mathrm{ad}_{p_f}\ap{Bf_\div}(\refl{\pt_G})\oldequiv\mathrm{ap}_{p_f}\refl{f(\pt_G)}\oldequiv\refl{\pt_H}\oldequiv e_H
-$$
+  \item the proposition $f^\abstr(e_G)= e_H$ holds through the
+    composite:
+    \begin{displaymath}
+      f^\abstr(e_G)\defequi\trp {\inv{p_f}}\ap{Bf_\div}(\refl{\pt_G})
+      = \inv{p_f} \cdot \refl{\pt_H} \cdot p_f = e_H
+    \end{displaymath}
 % Since $\ap{Bf}(e_G)\oldequiv \ap{Bf}f(\refl{\pt_G})\oldequiv\refl{f(\pt_G)}$ and $e_H\oldequiv\refl{\pt_H}$, 
 % $$f(e_G)\oldequiv\mathrm{ad}_p(\ap{Bf}(e_G))\oldequiv\mathrm{ad}_p(\refl{f(\pt_G)})\oldequiv \refl{\pt_H}\oldequiv e_H$$
-      \item the proposition $f^\abstr(g\cdot_Gg')=f^\abstr(g)\cdot_Hf^\abstr(g')$ is inhabited by the composite
-        \begin{align*}
-          f^\abstr(g\cdot_Gg')&\defequi %\mathrm{ad}_{p_f}\ap{Bf}(g\cdot g)\\\oldequiv&
-            \mathrm{ad}_{p_f}\ap{Bf}(g\, g')\\
-          &=\mathrm{ad}_{p_f}(\ap{Bf}(g)\,\ap{Bf}(g)')\\
-          %&= (\mathrm{ad}_{p_f}\ap{Bf}(g))\,{\mathrm{ad}_{p_f}\ap{Bf}(g)')\\
-          &=\mathrm{ad}_{p_f}\ap{Bf}(g)\cdot_H\mathrm{ad}_{p_f}\ap{Bf}(g')\oldequiv f^\abstr(g)\cdot_Hf^\abstr(g'),
-        \end{align*}
-where we have used that both $\ap{Bf_\div}$ and $\mathrm{ad}_{p_f}$ take composites of identities to composites of identities.
+  \item the proposition
+    $f^\abstr(g\cdot_Gg')=f^\abstr(g)\cdot_Hf^\abstr(g')$ contains an
+    element given by the composite:
+    \begin{align*}
+      f^\abstr(g\cdot_Gg')
+      &\defequi \trp{\inv{p_f}}\left(\ap{Bf_\div}(g\, g')\right)
+      \\
+      &=\trp{\inv{p_f}}(\ap{Bf_\div}(g)\,\ap{Bf_\div}(g)')
+      \\
+      &=\inv{p_f}\ap{Bf_\div}(g)\ap{Bf_\div}(g'){p_f}
+      \\
+      &=\inv{p_f}\ap{Bf_\div}(g)p_f\inv{p_f}\ap{Bf_\div}(g'){p_f}
+      \\
+      &=\trp{\inv{p_f}}\left(\ap{Bf_\div}(g)\right)
+        \cdot_H\trp{\inv{p_f}}\left(\ap{Bf_\div}(g')\right)
+      \\
+      &\jdeq f^\abstr(g)\cdot_Hf^\abstr(g'),
+    \end{align*}
+    where we have used that $\ap{Bf_\div}$ takes composites of
+    identities to composites of identities.
 
 If you find it useful, you may consider the following picture:
-$$\xymatrix{
-Bf_\div(\pt_G)\ar@{=}[rr]^{\ap{Bf_\div}(g\, g')}_\to\ar@{=}[dr]^{\ap{Bf_\div}(g')}_\to\ar@{=}[dd]_{p_f}^\downarrow
-&&Bf_\div(\pt_G)\ar@{=}[dd]_{p_f}^\downarrow\\
-&Bf_\div(\pt_G)\ar@{=}[d]_{p_f}^\downarrow
-\ar@{=}[ur]^{\ap{Bf_\div}(g)}_\to
+\begin{displaymath}
+  \xymatrix{
+Bf_\div(\pt_G)\ar@{=}[rr]^{\ap{Bf_\div}(g\, g')}_\to\ar@{=}[dr]^{\ap{Bf_\div}(g')}_{\rotatebox{-35}{\footnotesize$\to$}} \ar@{=}[dd]_{p_f}^\uparrow
+&&Bf_\div(\pt_G)\ar@{=}[dd]_{p_f}^\uparrow\\
+&Bf_\div(\pt_G)\ar@{=}[d]_{p_f}^\uparrow
+\ar@{=}[ur]^{\ap{Bf_\div}(g)}_{\rotatebox{35}{\footnotesize$\to$}}
 &\\
-\pt_H&\pt_H&\pt_H},$$
+\pt_H&\pt_H&\pt_H},
+\end{displaymath}
 where $f^\abstr(g\cdot_Gg')$ is simply ``up, over and down'' while $f^\abstr(g)\cdot_Hf^\abstr(g')$ takes the detour via the $\pt_H$ in the middle.
   \end{enumerate}
-\end{definition}
+\end{remark}
 \begin{definition}\label{def:abstrisfunctor}
-  If $\mathcal G\defequi(S,e_{\mathcal G},\mu_{\mathcal G},\iota_{\mathcal G})$ and $\mathcal H\defequi(T,e_{\mathcal H},\mu_{\mathcal H},\iota_{\mathcal H})$ are two abstract groups, then the set of homomorphisms from $\mathcal G$ to $\mathcal H$ is
+  If $\mathcal G\defequi(S,e_{\mathcal G},\cdot_{\mathcal G},\iota_{\mathcal G})$ and $\mathcal H\defequi(T,e_{\mathcal H},\cdot_{\mathcal H},\iota_{\mathcal H})$ are two abstract groups, then the set of homomorphisms from $\mathcal G$ to $\mathcal H$ is
  $$\Hom^\abstr(\mathcal G,\mathcal H)
 \defequi\sum_{f:S\to T}(e_{\mathcal H}=_Tf(e_{\mathcal G}))\times 
-(f\mu_{\mathcal G}=_{S\times S\to T}\mu_{\mathcal H}(f\times f)).
+\prod_{s,s':S}f(s\cdot_{\mathcal G}s')=_Tf(s)\cdot_{\mathcal H}f(s').
 $$
-Since $(e_{\mathcal H}=f(e_{\mathcal G}))\times (f\mu_{\mathcal G}=\mu_{\mathcal H}(f\times f))$ is a proposition, a homomorphism of abstract group is uniquely determined by its underlying function of sets, and unless there is danger of confusion we may write $f$ instead of $(f,!)$. 
+Since $(e_{\mathcal H}=f(e_{\mathcal G}))$ and
+$f(s\cdot_{\mathcal G}s')=_Tf(s)\cdot_{\mathcal H}f(s')$ for $s:S$ are
+propositions, a homomorphism of abstract group is uniquely determined
+by its underlying function of sets, and unless there is danger of
+confusion we may write $f$ instead of $(f,!)$.
 
 If $G$ and $H$ are groups, the function
 $$\abstr:\Hom(G,H)\to\Hom^\abstr(\abstr(G),\abstr(H))$$
-is the function $\abstr(f)=(f^\abstr,!)$ defined in \cref{def:grouphomomaxioms}.
+is defined as the function $f\mapsto \abstr(f)\defequi(f^\abstr,!)$
+made explicit in \cref{def:grouphomomaxioms}.
 \end{definition}
 \begin{xca}
   Note that the inverses play no r\^ole in the definition of a homomorphism of abstract groups.  Prove that if $(f,!):\Hom^\abstr(\mathcal G,\mathcal H)$
 %(G_{\Set},e_G,\mu_G,\iota_G),(H_{\Set},e_H,\mu_H,\iota_H))$ 
-then $f(g^{-1})=(f(g))^{-1}$, making a separate axiom redundant.  
+  then the proposition $f(g^{-1})=(f(g))^{-1}$ for all $g:\mathcal
+  G$, so that we don't have to require it separately.
 \end{xca}
 \begin{example}
   \label{ex:conjhomo}

--- a/macros.tex
+++ b/macros.tex
@@ -178,6 +178,8 @@
 \DeclareMathOperator\Succ{Succ}
 \DeclareMathOperator\fin{Fin}
 \DeclareMathOperator\El{El}
+\DeclareMathOperator\clf{B}
+
 
 \DeclarePairedDelimiter\Trunc{\lVert}{\rVert}
 \DeclarePairedDelimiter\trunc{\lvert}{\rvert} % truncation
@@ -261,6 +263,7 @@
 \newcommand{\typeabsgp}{\mathbf{Group}_{\mathrm{Abstract}}}
 \newcommand{\typemonoid}{\mathbf{Monoid}}
 \newcommand{\typetorsor}{\mathbf{Tors}}
+\newcommand{\permgrp}[1]{\Sigma_{{#1}}}%
 \newcommand{\BSigma}{B\Sigma}%previously \Set_{(S)} - the component of S:\Set
 \newcommand{\revers}{\mathit{r}}
 \newcommand{\twist}{\mathit{twist}}%loop in BC_2
@@ -288,6 +291,7 @@
 
 \newcommand{\blank}{{\_}}%
 \newcommand{\inv}[1]{{#1}^{-1}}%
+\newcommand{\ptdto}{\to_\ast}%
 
 %% paths over paths
 


### PR DESCRIPTION
This PR implements the changes decided with Marc and Bjørn on chapter 4 during the meeting on Feb. 17th 2020.

Noticeable changes include:

1. adapting the lemma that proves the equivalence between groups with inverse as a property or as a structure
2. providing a complete example of distincts group morphisms with same underlying function (using the permutation group on 3 elements)
3. introduce new macro for classifying types. For now only used in the definition of homomorphism, waiting on reactions before converting every B_ into \clf _.