### PR TITLE
Biber encoding error

### DIFF
--- a/macros.tex
+++ b/macros.tex
@@ -71,7 +71,8 @@
 \usepackage[backref=true,
             style=verbose,
             autocite=footnote,
-            backend=biber]{biblatex}
+            backend=biber,
+            bibencoding=utf8]{biblatex}
 \addbibresource{papers.bib}
 \let\cite\autocite
 \DefineBibliographyStrings{english}{%


### PR DESCRIPTION
I had an error issued by biber being the new backend for the bibliography. 

The error read as:
`ERROR - Data file 'papers.bib' cannot be read in encoding 'ascii': ascii "\xC5" does not map to Unicode at /usr/share/perl5/File/Slurper.pm line 59.`

Fixed it by adding `bibencoding=utf8` as an option on the biblatex package.

If the error was only on my side, please do not merge this PR, and I will investigate further why I got that. (Anyway, I think utf8 bibliography is better, but that can be discussed.)